### PR TITLE
Fix failing flash operations with gcc -O3

### DIFF
--- a/drivers/source/cy_flash.c
+++ b/drivers/source/cy_flash.c
@@ -168,6 +168,7 @@ cy_en_flashdrv_status_t Cy_Flash_WriteRow(uint32_t rowAddr, const uint32_t* data
         CPUSS_SYSARG = (uint32_t) &parameters[0U];
         CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_LOAD;
         __NOP();
+        __NOP();
 
         result = ProcessStatusCode();
         if(CY_FLASH_DRV_SUCCESS == result)
@@ -197,6 +198,7 @@ cy_en_flashdrv_status_t Cy_Flash_WriteRow(uint32_t rowAddr, const uint32_t* data
                         parameters[0U] |= (uint32_t)(rowNum << 16U);
                         CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_WRITE_ROW;
                     }
+                    __NOP();
                     __NOP();
 
                     result = ProcessStatusCode();
@@ -300,6 +302,7 @@ cy_en_flashdrv_status_t Cy_Flash_StartWrite(uint32_t rowAddr, const uint32_t* da
         CPUSS_SYSARG = (uint32_t) &parameters[0U];
         CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_LOAD;
         __NOP();
+        __NOP();
         result = ProcessStatusCode();
 
         if(result == CY_FLASH_DRV_SUCCESS)
@@ -328,6 +331,7 @@ cy_en_flashdrv_status_t Cy_Flash_StartWrite(uint32_t rowAddr, const uint32_t* da
 
                 CPUSS_SYSARG = (uint32_t) &parameters[0U];
                 CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_NON_BLOCKING_WRITE_ROW;
+                __NOP();
                 __NOP();
                 result = ProcessStatusCode();
             }
@@ -373,6 +377,7 @@ cy_en_flashdrv_status_t Cy_Flash_ResumeWrite(void)
     CPUSS_SYSARG = (uint32_t) &parameters[0U];
     CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_RESUME_NON_BLOCKING;
 
+    __NOP();
     __NOP();
     result = ProcessStatusCode();
 
@@ -482,6 +487,7 @@ cy_en_flashdrv_status_t Cy_Flash_RowChecksum(uint32_t rowAddr, uint32_t* checksu
 
         CPUSS_SYSARG = (uint32_t) parameters[0U];
         CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_CHECKSUM;
+        __NOP();
         __NOP();
         result = ProcessStatusCode();
         if (CY_FLASH_DRV_SUCCESS == result)
@@ -663,6 +669,7 @@ static cy_en_flashdrv_status_t Cy_Flash_ClockBackup(void)
     CPUSS_SYSARG = (uint32_t) &parameters[0U];
     CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_CLK_BACKUP;
     __NOP();
+    __NOP();
     result = ProcessStatusCode();
 
     /* Enabling IMO after backup completion as required by hardware.
@@ -692,6 +699,7 @@ static cy_en_flashdrv_status_t Cy_Flash_ClockConfig(void)
                     CY_FLASH_KEY_ONE);
     CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_CLK_CONFIG;
     __NOP();
+    __NOP();
     result = ProcessStatusCode();
 
     return (result);
@@ -720,6 +728,7 @@ static cy_en_flashdrv_status_t Cy_Flash_ClockRestore(void)
     CPUSS_SYSARG = (uint32_t) &parameters[0U];
     CPUSS_SYSREQ = CY_FLASH_CPUSS_REQ_START | CY_FLASH_API_OPCODE_CLK_RESTORE;
 
+    __NOP();
     __NOP();
     result = ProcessStatusCode();
 


### PR DESCRIPTION

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

### Description
When compiling for PSoC4 with GCC and compile flag **-O3**, flash operations fail because `CPUSS_SYSARG` is read out too closely after `CPUSS_SYSREQ` has been set. Using two `__NOP()`s instead of one after setting `CPUSS_SYSREQ` is sufficient to overcome this.

### Related Issue
None

### Context
The problem was observed on proprietary hardware with a PSoC4 S Max and on a Rutronics RDK4 evaluation board.
The value of `CPUSS_SYSARG` in `ProcessStatusCode()` was neither `SROMCODE_SUCCESS` nor `SROMCODE_ERROR_FLAG` and thus `ProcessStatusCode()` returned `CY_FLASH_DRV_OPERATION_STARTED`, even though `CY_FLASH_NON_BLOCKING_SUPPORTED` was not set.
Adding the extra `__NOP()`s apparently gives the processor enough time to update the `CPUSS_SYSARG` register.
